### PR TITLE
Updated way of fetching client API tokens

### DIFF
--- a/app/src/main/java/ua/safetynet/payment/ClientTokenFetch.java
+++ b/app/src/main/java/ua/safetynet/payment/ClientTokenFetch.java
@@ -61,6 +61,10 @@ public class ClientTokenFetch {
             }
         });
     }
+    /**
+     * Gets client token from PayPal Payouts REST API. Uses clientId and secret stored in secrets.xml
+     *
+     */
     public void fetchPaypalToken() {
         String clientId = context.getString(R.string.paypal_client_id);
         String secret = context.getString(R.string.paypal_secret);

--- a/app/src/main/java/ua/safetynet/payment/ClientTokenFetch.java
+++ b/app/src/main/java/ua/safetynet/payment/ClientTokenFetch.java
@@ -1,0 +1,105 @@
+package ua.safetynet.payment;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Looper;
+import android.os.Process;
+import android.support.annotation.NonNull;
+import android.util.Log;
+
+import com.loopj.android.http.AsyncHttpClient;
+import com.loopj.android.http.AsyncHttpResponseHandler;
+import com.loopj.android.http.JsonHttpResponseHandler;
+import com.loopj.android.http.RequestParams;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import cz.msebera.android.httpclient.Header;
+import ua.safetynet.R;
+
+public class ClientTokenFetch {
+    private String braintreeClientToken;
+    private String paypalClientToken;
+    private String userId;
+    private Context context;
+    private static final String SERVERURL = "https://safetynet-495.herokuapp.com/";
+    private static final String SERVERTOKEN = "client_token/";
+    private static final int SERVERPORT = 443;
+    private static final int APIPORT = 443;
+    private static final String APIBASEURL = "https://api.sandbox.paypal.com/";
+    private static final String APITOKENURL = "v1/oauth2/token";
+    private static final String TAG = "ClientTokenRunnable";
+    private SharedPreferences sharedPrefs;
+
+    public ClientTokenFetch(Context context) {
+        this.context = context;
+        sharedPrefs = this.context.getSharedPreferences("tokens",Context.MODE_PRIVATE );
+    }
+    public void setContext(Context context) {
+        this.context = context;
+    }
+
+    public void fetchBraintreeToken() {
+        AsyncHttpClient clientBt = new AsyncHttpClient(SERVERPORT);
+        clientBt.setURLEncodingEnabled(true);
+        clientBt.get(SERVERURL + SERVERTOKEN + userId, new AsyncHttpResponseHandler() {
+            @Override
+            public void onFailure(int statusCode, Header[] headers, byte[] responseBody, Throwable throwable) {
+                Log.d(TAG, "Failed to fetch client token");
+            }
+
+            @Override
+            public void onSuccess(int statusCode, Header[] headers, byte[] responseBody) {
+                braintreeClientToken = new String(responseBody);
+                saveBtToSharedPrefs(braintreeClientToken);
+                Log.d(TAG, "Got Braintree token");
+            }
+        });
+    }
+    public void fetchPaypalToken() {
+        String clientId = context.getString(R.string.paypal_client_id);
+        String secret = context.getString(R.string.paypal_secret);
+        AsyncHttpClient client = new AsyncHttpClient(APIPORT);
+        client.setAuthenticationPreemptive(true);
+        client.setBasicAuth(clientId, secret);
+        client.addHeader("content-type", "application/x-www-form-urlencoded");
+        RequestParams params = new RequestParams();
+        params.put("grant_type", "client_credentials");
+        client.post(APIBASEURL + APITOKENURL,params, new JsonHttpResponseHandler() {
+            @Override
+            public void onSuccess(int statusCode, Header[] headers, JSONObject response) {
+                try {
+                    paypalClientToken = response.getString("access_token");
+                    savePaypalToSharedPrefs(paypalClientToken);
+                    Log.d(TAG, "Fetched client token");
+                } catch (JSONException e) {
+                    Log.d(TAG, "Could not parse client token xml data");
+                }
+            }
+
+            @Override
+            public void onFailure(int statusCode, Header[] headers, Throwable t, JSONObject json) {
+                Log.d(TAG, "Could not fetch client token" + t.toString() + json.toString());
+            }
+        });
+    }
+    private void saveBtToSharedPrefs(String token) {
+        //Save token to shared prefs. apply() for async update
+        SharedPreferences.Editor editor = sharedPrefs.edit();
+        editor.putString("braintree", token);
+        editor.apply();
+    }
+    private void savePaypalToSharedPrefs(String token) {
+        //Save token to shared prefs. apply() for async update
+        SharedPreferences.Editor editor = sharedPrefs.edit();
+        editor.putString("paypal", token);
+        editor.apply();
+    }
+    public String getBraintreeToken() {
+        return braintreeClientToken;
+    }
+    public String getPaypalToken() {
+        return paypalClientToken;
+    }
+}

--- a/app/src/main/java/ua/safetynet/payment/ClientTokenFetch.java
+++ b/app/src/main/java/ua/safetynet/payment/ClientTokenFetch.java
@@ -40,6 +40,10 @@ public class ClientTokenFetch {
         this.context = context;
     }
 
+    /**
+     * Uses HTTP library to make call to server to fetch client token. Passes userId to server
+     * so Braintree can treat them as a returning customer
+     */
     public void fetchBraintreeToken() {
         AsyncHttpClient clientBt = new AsyncHttpClient(SERVERPORT);
         clientBt.setURLEncodingEnabled(true);

--- a/app/src/main/java/ua/safetynet/payment/PaymentFragment.java
+++ b/app/src/main/java/ua/safetynet/payment/PaymentFragment.java
@@ -124,12 +124,12 @@ public class PaymentFragment extends Fragment {
                         updateUser(user);
                     }
                 });
+        //Call the fetch regardless in case it has expired
+        new ClientTokenFetch(getContext()).fetchBraintreeToken();
         //Setup shared prefs to get token from
         try {
             sharedPrefs = getContext().getSharedPreferences("tokens", Context.MODE_PRIVATE);
             clientToken = sharedPrefs.getString("braintree", null);
-            if(clientToken == null)
-                new ClientTokenFetch(getContext()).fetchBraintreeToken();
         }
         catch (NullPointerException e) {
             e.printStackTrace();

--- a/app/src/main/java/ua/safetynet/payment/PayoutFragment.java
+++ b/app/src/main/java/ua/safetynet/payment/PayoutFragment.java
@@ -108,12 +108,13 @@ public class PayoutFragment extends Fragment {
             amount = new BigDecimal(getArguments().getString(AMOUNT));
             groupId = getArguments().getString(GROUPID);
         }
+
+        //Call the fetch regardless in case it has expired
+        new ClientTokenFetch(getContext()).fetchPaypalToken();
         //Setup shared prefs to get token from
         try {
             sharedPrefs = getContext().getSharedPreferences("tokens", Context.MODE_PRIVATE);
             clientToken = sharedPrefs.getString("paypal", null);
-            if(clientToken == null)
-                new ClientTokenFetch(getContext()).fetchPaypalToken();
         }
         catch (NullPointerException e) {
             e.printStackTrace();

--- a/app/src/main/java/ua/safetynet/payment/PayoutFragment.java
+++ b/app/src/main/java/ua/safetynet/payment/PayoutFragment.java
@@ -1,6 +1,7 @@
 package ua.safetynet.payment;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.icu.text.SimpleDateFormat;
 import android.net.Uri;
 import android.os.Bundle;
@@ -74,6 +75,7 @@ public class PayoutFragment extends Fragment {
     private MaterialSpinner spinner;
     private OnPayoutCompleteListener mListener;
     private TransactionDialog transactionDialog;
+    private SharedPreferences sharedPrefs;
     public PayoutFragment() {
         // Required empty public constructor
     }
@@ -102,11 +104,21 @@ public class PayoutFragment extends Fragment {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        getClientToken();
         if (getArguments() != null) {
             amount = new BigDecimal(getArguments().getString(AMOUNT));
             groupId = getArguments().getString(GROUPID);
         }
+        //Setup shared prefs to get token from
+        try {
+            sharedPrefs = getContext().getSharedPreferences("tokens", Context.MODE_PRIVATE);
+            clientToken = sharedPrefs.getString("paypal", null);
+            if(clientToken == null)
+                new ClientTokenFetch(getContext()).fetchPaypalToken();
+        }
+        catch (NullPointerException e) {
+            e.printStackTrace();
+        }
+
     }
 
     /**
@@ -201,6 +213,7 @@ public class PayoutFragment extends Fragment {
     }
 
     private void makeWithdrawal() {
+        clientToken = sharedPrefs.getString("paypal", null);
         AsyncHttpClient client = new AsyncHttpClient(APIPORT);
         JSONObject jsonReq = makePayoutsJson(emailText.getText().toString(), amount.toPlainString());
         StringEntity entity = null;
@@ -228,36 +241,8 @@ public class PayoutFragment extends Fragment {
         });
     }
 
-    /**
-     * Gets client token from PayPal Payouts REST API. Uses clientId and secret stored in secrets.xml
-     *
-     */
-    private void getClientToken() {
-        String clientId = getString(R.string.paypal_client_id);
-        String secret = getString(R.string.paypal_secret);
-        AsyncHttpClient client = new AsyncHttpClient(APIPORT);
-        client.setAuthenticationPreemptive(true);
-        client.setBasicAuth(clientId, secret);
-        client.addHeader("content-type", "application/x-www-form-urlencoded");
-        RequestParams params = new RequestParams();
-        params.put("grant_type", "client_credentials");
-        client.post(APIBASEURL + APITOKENURL,params, new JsonHttpResponseHandler() {
-            @Override
-            public void onSuccess(int statusCode, Header[] headers, JSONObject response) {
-                try {
-                    clientToken = response.getString("access_token");
-                    Log.d(TAG, "Fetched client token");
-                } catch (JSONException e) {
-                    Log.d(TAG, "Could not parse client token xml data");
-                }
-            }
 
-            @Override
-            public void onFailure(int statusCode, Header[] headers, Throwable t, JSONObject json) {
-                Log.d(TAG, "Could not fetch client token" + t.toString() + json.toString());
-            }
-        });
-    }
+
     private JSONObject makePayoutsJson(String email, String amount) {
         JSONObject json = new JSONObject();
         JSONObject senderHeader = new JSONObject();

--- a/app/src/main/java/ua/safetynet/user/MainPageActivity.java
+++ b/app/src/main/java/ua/safetynet/user/MainPageActivity.java
@@ -3,7 +3,6 @@ package ua.safetynet.user;
 
 import android.content.Intent;
 import android.net.Uri;
-import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 import android.support.design.widget.NavigationView;
 import android.support.v4.app.Fragment;
@@ -15,7 +14,6 @@ import android.os.Bundle;
 import android.util.Log;
 import android.view.MenuItem;
 import android.support.v7.widget.Toolbar;
-import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.firebase.ui.auth.AuthUI;
@@ -28,15 +26,17 @@ import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.FirebaseFirestoreSettings;
 
 import java.math.BigDecimal;
-import java.util.Arrays;
 import java.util.Calendar;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import ua.safetynet.Database;
 import ua.safetynet.R;
 import ua.safetynet.auth.FirebaseAuthActivity;
-import ua.safetynet.auth.SplashScreenActivity;
 import ua.safetynet.group.CreateGroupFragment;
 import ua.safetynet.group.Group;
+import ua.safetynet.payment.ClientTokenFetch;
 import ua.safetynet.payment.PaymentFragment;
 import ua.safetynet.payment.PayoutFragment;
 import ua.safetynet.payment.Transaction;
@@ -64,13 +64,19 @@ public class MainPageActivity extends AppCompatActivity implements CreateGroupFr
     protected void onStart()
     {
         super.onStart();
-        firebaseAuth = FirebaseAuth.getInstance();
-        firebaseUser = firebaseAuth.getCurrentUser();
     }
     @Override
     protected void onCreate(Bundle savedInstanceState)
     {
+        firebaseAuth = FirebaseAuth.getInstance();
+        firebaseUser = firebaseAuth.getCurrentUser();
         super.onCreate(savedInstanceState);
+        //Set runnable for client tokens
+        if(firebaseUser != null) {
+            ClientTokenFetch tokenFetch = new ClientTokenFetch(getApplicationContext());
+            tokenFetch.fetchBraintreeToken();
+            tokenFetch.fetchPaypalToken();
+        }
         //Set Firestore settings to use Timestamp
         FirebaseFirestore firestore = FirebaseFirestore.getInstance();
         FirebaseFirestoreSettings settings = new FirebaseFirestoreSettings.Builder()
@@ -247,4 +253,5 @@ public class MainPageActivity extends AppCompatActivity implements CreateGroupFr
     public void setUser(User user) {
         this.user = user;
     }
+
 }


### PR DESCRIPTION
Previously I was just making the requests for API tokens for Braintree and Paypal Payouts in the onCreate of the respective fragments. This caused the user to occasionally have to wait for the token response before continuing . So I made a new class and try to fetch on app startup, then store them in the shared preferences. 
Payments and Payouts then get them from the shared prefs. Tried to do with with a WorkScheduler to keep them from expiring, but that ended up taking too long, so I went with this approach, which while it works it could be better.